### PR TITLE
Fix the scoreboard calculations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "replay-viewer",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Rocket League replay viewer React component and tooling",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/viewer/components/ScoreBoard.tsx
+++ b/src/viewer/components/ScoreBoard.tsx
@@ -49,9 +49,10 @@ export default class Scoreboard extends PureComponent<Props, State> {
     this.onFrame.cancel()
   }
 
-  getDateTimeString() {
-    const { gameTime } = this.state
-
+  getTimerString() {
+    let { gameTime } = this.state
+    // The frame is filled as -100 when the data is missing, so we set the minimum to 0
+    gameTime = gameTime < 0 ? 0 : gameTime
     const seconds = gameTime % 60
     const minutes = (gameTime - seconds) / 60
     const secondsString = seconds < 10 ? `0${seconds}` : seconds
@@ -66,7 +67,7 @@ export default class Scoreboard extends PureComponent<Props, State> {
           <Score>{team0Score}</Score>
         </BlueScoreCard>
         <GameTimeCard>
-          <GameTime>{this.getDateTimeString()}</GameTime>
+          <GameTime>{this.getTimerString()}</GameTime>
         </GameTimeCard>
         <OrangeScoreCard>
           <Score>{team1Score}</Score>


### PR DESCRIPTION
Fixes #46. Since we [fill in -100](https://github.com/SaltieRL/DistributedReplays/blob/5ecf61651d79912358c451f0a7e14d7ae2aa454e/backend/blueprints/spa_api/service_layers/replay/replay_positions.py#L45) when we don't have values for a frame, this breaks the calculation.