### PR TITLE
Return elapsed time based on current frame

### DIFF
--- a/src/eventbus/events/frame.ts
+++ b/src/eventbus/events/frame.ts
@@ -6,6 +6,7 @@ import EventBus from "../EventBus"
  */
 export interface FrameEvent {
   frame: number
+  elapsedTime: number
 }
 
 export const {

--- a/src/utils/FPSClock.ts
+++ b/src/utils/FPSClock.ts
@@ -111,6 +111,13 @@ export default class FPSClock {
     return delta / 1000
   }
 
+  /**
+   * Returns the elapsed time in milliseconds.
+   */
+  public getElapsedTime() {
+    return this.frameToDuration[this.currentFrame]
+  }
+
   private update() {
     if (!this.paused) {
       this.getElapsedFrames()
@@ -139,7 +146,10 @@ export default class FPSClock {
   }
 
   private doCallbacks() {
-    dispatchFrameEvent({ frame: this.currentFrame })
+    dispatchFrameEvent({
+      frame: this.currentFrame,
+      elapsedTime: this.getElapsedTime(),
+    })
   }
 
   /**


### PR DESCRIPTION
Passes the elapsed time in milliseconds to each callback function