### PR TITLE
Pass delta into frame callbacks

### DIFF
--- a/src/eventbus/events/frame.ts
+++ b/src/eventbus/events/frame.ts
@@ -5,6 +5,7 @@ import EventBus from "../EventBus"
  * Fires each time the global game clock advances a frame or updates its current frame.
  */
 export interface FrameEvent {
+  delta: number
   frame: number
   elapsedTime: number
 }

--- a/src/managers/GameManager.ts
+++ b/src/managers/GameManager.ts
@@ -52,9 +52,7 @@ export class GameManager {
     paused ? this.clock.pause() : this.clock.play()
   }
 
-  animate({  }: FrameEvent) {
-    const delta = this.clock.getDelta()
-
+  animate({ delta }: FrameEvent) {
     if (delta) {
       AnimationManager.getInstance().updateAnimationClips(delta)
       this.render()

--- a/src/managers/SceneManager.ts
+++ b/src/managers/SceneManager.ts
@@ -1,6 +1,10 @@
 import { Scene } from "three"
 
-import { addFrameListener, removeFrameListener } from "../eventbus/events/frame"
+import {
+  addFrameListener,
+  FrameEvent,
+  removeFrameListener,
+} from "../eventbus/events/frame"
 import BallManager from "./models/BallManager"
 import FieldManager from "./models/FieldManager"
 import PlayerManager from "./models/PlayerManager"
@@ -27,7 +31,7 @@ export default class SceneManager {
     addFrameListener(this.update)
   }
 
-  private readonly update = () => {
+  private readonly update = ({ delta }: FrameEvent) => {
     for (const player of this.players) {
       if (player.carGroup.position.y < 0) {
         player.carGroup.visible = false

--- a/src/utils/FPSClock.ts
+++ b/src/utils/FPSClock.ts
@@ -79,6 +79,13 @@ export default class FPSClock {
   }
 
   /**
+   * Returns the elapsed time in milliseconds.
+   */
+  public getElapsedTime() {
+    return this.frameToDuration[this.currentFrame]
+  }
+
+  /**
    * Returns the number of seconds elapsed since the last time getDelta was called. This function
    * uses a combination of the performance.now() functionality when animations are rolling,
    * combined with a small queue of delta modifications made by the setFrame function. This will
@@ -87,7 +94,7 @@ export default class FPSClock {
    *
    * @returns {number} seconds
    */
-  public getDelta(): number {
+  private getDelta(): number {
     const now = performance.now()
     // Initialize empty delta
     if (!this.lastDelta) {
@@ -109,13 +116,6 @@ export default class FPSClock {
     // Use the elapsed deltas for bookkeeping
     this.elapsedTime += delta
     return delta / 1000
-  }
-
-  /**
-   * Returns the elapsed time in milliseconds.
-   */
-  public getElapsedTime() {
-    return this.frameToDuration[this.currentFrame]
   }
 
   private update() {
@@ -147,6 +147,7 @@ export default class FPSClock {
 
   private doCallbacks() {
     dispatchFrameEvent({
+      delta: this.getDelta(),
       frame: this.currentFrame,
       elapsedTime: this.getElapsedTime(),
     })


### PR DESCRIPTION
The `getDelta` function is unsafe, since it can only be called in one spot and impacts performance of the rest of the app. This makes that function call private and moves it into the FrameEvents so all subscribers can take advantage of the realtime delta.