### PR TITLE
Add compact player controls and support for custom wrapped components

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -14,7 +14,7 @@ class App extends Component<any, State> {
   constructor(props: any) {
     super(props)
     this.state = {
-      tab: "viewer",
+      tab: "compact",
     }
   }
 

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -4,7 +4,7 @@ import React, { Component } from "react"
 
 import Main from "./components/Main"
 
-type ActiveTab = "viewer" | "other"
+type ActiveTab = "viewer" | "compact" | "other"
 
 interface State {
   tab: ActiveTab
@@ -33,9 +33,11 @@ class App extends Component<any, State> {
         </div>
         <Tabs value={tab} onChange={this.handleChange}>
           <Tab label="Viewer" value="viewer" />
+          <Tab label="Compact" value="compact" />
           <Tab label="Other" value="other" />
         </Tabs>
         {tab === "viewer" && <Main />}
+        {tab === "compact" && <Main compact />}
         {tab === "other" && <div>Other</div>}
       </div>
     )

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -14,7 +14,7 @@ class App extends Component<any, State> {
   constructor(props: any) {
     super(props)
     this.state = {
-      tab: "compact",
+      tab: "viewer",
     }
   }
 

--- a/docs/src/components/CompactViewer.tsx
+++ b/docs/src/components/CompactViewer.tsx
@@ -1,0 +1,55 @@
+import Grid from "@material-ui/core/Grid"
+import React, { Component } from "react"
+
+import {
+  CompactPlayControls,
+  GameBuilderOptions,
+  GameManager,
+  GameManagerLoader,
+  ReplayViewer,
+} from "../../../src"
+
+interface Props {
+  options: GameBuilderOptions
+}
+
+interface State {
+  gameManager?: GameManager
+}
+
+class CompactViewer extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = {}
+  }
+
+  renderContent() {
+    const { gameManager } = this.state
+
+    if (!gameManager) {
+      return "Food machine broke..."
+    }
+
+    return (
+      <Grid container direction="column" justify="center" spacing={24}>
+        <Grid item style={{ minHeight: 0, maxWidth: 900, width: "100%" }}>
+          <ReplayViewer gameManager={gameManager}>
+            <CompactPlayControls />
+          </ReplayViewer>
+        </Grid>
+      </Grid>
+    )
+  }
+
+  render() {
+    const { options } = this.props
+    const onLoad = (gm: GameManager) => this.setState({ gameManager: gm })
+    return (
+      <GameManagerLoader options={options} onLoad={onLoad}>
+        {this.renderContent()}
+      </GameManagerLoader>
+    )
+  }
+}
+
+export default CompactViewer

--- a/docs/src/components/Main.tsx
+++ b/docs/src/components/Main.tsx
@@ -1,14 +1,25 @@
 import React, { Component } from "react"
 
-import { FPSClock, GameBuilderOptions, loadReplay } from "../../../src"
+import {
+  FPSClock,
+  GameBuilderOptions,
+  loadReplay,
+  ReplayData,
+  ReplayMetadata,
+} from "../../../src"
+import CompactViewer from "./CompactViewer"
 import Viewer from "./Viewer"
+
+interface Props {
+  compact?: boolean
+}
 
 interface State {
   options?: GameBuilderOptions
 }
 
-class Main extends Component<any, State> {
-  constructor(props: any) {
+class Main extends Component<Props, State> {
+  constructor(props: Props) {
     super(props)
     this.state = {}
   }
@@ -16,7 +27,7 @@ class Main extends Component<any, State> {
   componentDidMount() {
     const REPLAY_ID = "9944A36A11E987D3E286C1B524E68ECC"
 
-    loadReplay(REPLAY_ID).then(([replayData, replayMetadata]) => {
+    loadReplay(REPLAY_ID, true).then(([replayData, replayMetadata]) => {
       this.setState({
         options: {
           replayData,
@@ -33,8 +44,11 @@ class Main extends Component<any, State> {
     if (!options) {
       return "Loading..."
     }
-
-    return <Viewer options={options} />
+    return this.props.compact ? (
+      <CompactViewer options={options} />
+    ) : (
+      <Viewer options={options} />
+    )
   }
 }
 

--- a/docs/src/components/Viewer.tsx
+++ b/docs/src/components/Viewer.tsx
@@ -44,7 +44,7 @@ class Viewer extends Component<Props, State> {
         spacing={24}
       >
         <Grid item style={{ minHeight: 0, maxWidth: 900, width: "100%" }}>
-          <ReplayViewer gameManager={gameManager} />
+          <ReplayViewer gameManager={gameManager} autoplay />
         </Grid>
         <Grid item>
           <Grid

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "replay-viewer",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Rocket League replay viewer React component and tooling",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,9 @@ export { default as ReplayViewer } from "./viewer/components/ReplayViewer"
 export {
   default as GameManagerLoader,
 } from "./viewer/components/GameManagerLoader"
+export {
+  default as CompactPlayControls,
+} from "./viewer/components/CompactPlayControls"
 export { default as PlayControls } from "./viewer/components/PlayControls"
 export {
   default as PlayerCameraControls,

--- a/src/managers/GameManager.ts
+++ b/src/managers/GameManager.ts
@@ -41,7 +41,10 @@ export class GameManager {
     this.render = this.render.bind(this)
     this.clock = clock
 
+    // Spawns the animation clips
     AnimationManager.getInstance().playAnimationClips()
+    // Forces every animation to "take position"
+    AnimationManager.getInstance().updateAnimationClips(0)
     addPlayPauseListener(this.onPlayPause)
     addFrameListener(this.animate)
     addCanvasResizeListener(this.updateSize)

--- a/src/viewer/clients/loadReplay.ts
+++ b/src/viewer/clients/loadReplay.ts
@@ -10,11 +10,25 @@ const fetchByURL = (url: string) =>
     },
   }).then(response => response.json())
 
-export const loadReplay = (
-  replayId: string
+const cache: { [key: string]: [ReplayData, ReplayMetadata] } = {}
+
+export const loadReplay = async (
+  replayId: string,
+  cached?: boolean
 ): Promise<[ReplayData, ReplayMetadata]> => {
-  return Promise.all([
-    fetchByURL(`https://calculated.gg/api/replay/${replayId}/positions`),
-    fetchByURL(`https://calculated.gg/api/v1/replay/${replayId}?key=1`),
-  ])
+  const fetch = () =>
+    Promise.all([
+      fetchByURL(`https://calculated.gg/api/replay/${replayId}/positions`),
+      fetchByURL(`https://calculated.gg/api/v1/replay/${replayId}?key=1`),
+    ])
+  if (cached) {
+    if (!cache[replayId]) {
+      return fetch().then(data => {
+        cache[replayId] = data
+        return data
+      })
+    }
+    return Promise.resolve(cache[replayId])
+  }
+  return fetch()
 }

--- a/src/viewer/components/CompactPlayControls.tsx
+++ b/src/viewer/components/CompactPlayControls.tsx
@@ -1,23 +1,35 @@
 import Button from "@material-ui/core/Button"
+import Dialog from "@material-ui/core/Dialog"
+import DialogContent from "@material-ui/core/DialogContent"
+import DialogTitle from "@material-ui/core/DialogTitle"
 import Grid from "@material-ui/core/Grid"
 import withStyles, { WithStyles } from "@material-ui/core/styles/withStyles"
+import Typography from "@material-ui/core/Typography"
 import React, { Component } from "react"
 import styled from "styled-components"
 
+import {
+  addCameraChangeListener,
+  removeCameraChangeListener,
+} from "../../eventbus/events/cameraChange"
 import {
   addPlayPauseListener,
   dispatchPlayPauseEvent,
   PlayPauseEvent,
   removePlayPauseListener,
 } from "../../eventbus/events/playPause"
+import FieldCameraControls from "./FieldCameraControls"
+import Camera from "./icons/Camera"
 import PausedIcon from "./icons/PausedIcon"
 import PlayIcon from "./icons/PlayIcon"
+import PlayerCameraControls from "./PlayerCameraControls"
 import Slider from "./Slider"
 
 interface Props extends WithStyles {}
 
 interface State {
   paused: boolean
+  cameraControlsShowing: boolean
 }
 
 class CompactPlayControls extends Component<Props, State> {
@@ -25,13 +37,16 @@ class CompactPlayControls extends Component<Props, State> {
     super(props)
     this.state = {
       paused: false,
+      cameraControlsShowing: false,
     }
 
     addPlayPauseListener(this.onPlayPause)
+    addCameraChangeListener(this.hideCameraControls)
   }
 
   componentWillUnmount() {
     removePlayPauseListener(this.onPlayPause)
+    removeCameraChangeListener(this.hideCameraControls)
   }
 
   setPlayPause = () => {
@@ -47,8 +62,20 @@ class CompactPlayControls extends Component<Props, State> {
     })
   }
 
+  showCameraControls = () => {
+    this.setState({
+      cameraControlsShowing: true,
+    })
+  }
+
+  hideCameraControls = () => {
+    this.setState({
+      cameraControlsShowing: false,
+    })
+  }
+
   render() {
-    const { paused } = this.state
+    const { paused, cameraControlsShowing } = this.state
     const { focused, thumb, track } = this.props.classes
     return (
       <ControlsWrapper>
@@ -67,7 +94,21 @@ class CompactPlayControls extends Component<Props, State> {
               }}
             />
           </Grid>
+          <Grid item>
+            <Button onClick={this.showCameraControls}>
+              <Camera />
+            </Button>
+          </Grid>
         </Grid>
+        <Dialog open={cameraControlsShowing} onClose={this.hideCameraControls}>
+          <DialogTitle>Camera Controls</DialogTitle>
+          <DialogContent>
+            <Typography>Field Cameras</Typography>
+            <FieldCameraControls />
+            <Typography>Player Cameras</Typography>
+            <PlayerCameraControls />
+          </DialogContent>
+        </Dialog>
       </ControlsWrapper>
     )
   }

--- a/src/viewer/components/CompactPlayControls.tsx
+++ b/src/viewer/components/CompactPlayControls.tsx
@@ -1,0 +1,94 @@
+import Button from "@material-ui/core/Button"
+import Grid from "@material-ui/core/Grid"
+import withStyles, { WithStyles } from "@material-ui/core/styles/withStyles"
+import React, { Component } from "react"
+import styled from "styled-components"
+
+import {
+  addPlayPauseListener,
+  dispatchPlayPauseEvent,
+  PlayPauseEvent,
+  removePlayPauseListener,
+} from "../../eventbus/events/playPause"
+import PausedIcon from "./icons/PausedIcon"
+import PlayIcon from "./icons/PlayIcon"
+import Slider from "./Slider"
+
+interface Props extends WithStyles {}
+
+interface State {
+  paused: boolean
+}
+
+class CompactPlayControls extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = {
+      paused: false,
+    }
+
+    addPlayPauseListener(this.onPlayPause)
+  }
+
+  componentWillUnmount() {
+    removePlayPauseListener(this.onPlayPause)
+  }
+
+  setPlayPause = () => {
+    const isPaused = this.state.paused
+    dispatchPlayPauseEvent({
+      paused: !isPaused,
+    })
+  }
+
+  onPlayPause = ({ paused }: PlayPauseEvent) => {
+    this.setState({
+      paused,
+    })
+  }
+
+  render() {
+    const { paused } = this.state
+    const { focused, thumb, track } = this.props.classes
+    return (
+      <ControlsWrapper>
+        <Grid container spacing={24} alignItems="center">
+          <Grid item>
+            <Button onClick={this.setPlayPause}>
+              {paused ? <PlayIcon /> : <PausedIcon />}
+            </Button>
+          </Grid>
+          <Grid item zeroMinWidth xs>
+            <Slider
+              classes={{
+                thumb,
+                track,
+                focused,
+              }}
+            />
+          </Grid>
+        </Grid>
+      </ControlsWrapper>
+    )
+  }
+}
+
+const ControlsWrapper = styled.div`
+  position: absolute;
+  bottom: 6px;
+  left: 12px;
+  right: 60px;
+`
+
+export default withStyles({
+  focused: {},
+  track: {
+    backgroundColor: "#fff",
+  },
+  thumb: {
+    backgroundColor: "#fff",
+    "&:focus,&:hover,&$active": {
+      boxShadow: "inherit",
+    },
+  },
+})(CompactPlayControls)

--- a/src/viewer/components/GameManagerLoader.tsx
+++ b/src/viewer/components/GameManagerLoader.tsx
@@ -45,7 +45,7 @@ class GameManagerLoader extends Component<Props, State> {
     GameManager.destruct()
   }
 
-  handleProgress = (item: any, loaded: number, total: number) => {
+  handleProgress = (_: any, loaded: number, total: number) => {
     const newPercent = Math.round((loaded / total) * 1000) / 10
     const { percentLoaded } = this.state
     const stateValue = newPercent > percentLoaded ? newPercent : percentLoaded

--- a/src/viewer/components/ReplayViewer.tsx
+++ b/src/viewer/components/ReplayViewer.tsx
@@ -12,6 +12,7 @@ import Scoreboard from "./ScoreBoard"
 
 interface Props {
   gameManager: GameManager
+  autoplay?: boolean
 }
 
 interface State {
@@ -34,10 +35,15 @@ class ReplayViewer extends PureComponent<Props, State> {
     if (!current) {
       throw new Error("Did not mount replay viewer correctly")
     }
-    const { gameManager } = this.props
+    const { gameManager, autoplay } = this.props
+    // Mount and resize canvas
     current.appendChild(gameManager.getDOMNode())
     this.handleResize()
-    gameManager.clock.play()
+
+    // Only start when explicitly asked
+    if (autoplay) {
+      gameManager.clock.play()
+    }
 
     addEventListener("resize", this.handleResize)
   }

--- a/src/viewer/components/ReplayViewer.tsx
+++ b/src/viewer/components/ReplayViewer.tsx
@@ -5,6 +5,7 @@ import FullScreen from "react-full-screen"
 import styled from "styled-components"
 
 import { dispatchCanvasResizeEvent } from "../../eventbus/events/canvasResize"
+import { dispatchPlayPauseEvent } from "../../eventbus/events/playPause"
 import { GameManager } from "../../managers/GameManager"
 import FullscreenExitIcon from "./icons/FullscreenExitIcon"
 import FullscreenIcon from "./icons/FullscreenIcon"
@@ -40,10 +41,8 @@ class ReplayViewer extends PureComponent<Props, State> {
     current.appendChild(gameManager.getDOMNode())
     this.handleResize()
 
-    // Only start when explicitly asked
-    if (autoplay) {
-      gameManager.clock.play()
-    }
+    // Set the play/pause status to match autoplay property
+    dispatchPlayPauseEvent({ paused: !autoplay })
 
     addEventListener("resize", this.handleResize)
   }

--- a/src/viewer/components/ReplayViewer.tsx
+++ b/src/viewer/components/ReplayViewer.tsx
@@ -77,6 +77,7 @@ class ReplayViewer extends PureComponent<Props, State> {
               </Typography>
             </Button>
           </FullscreenToggle>
+          {this.props.children}
         </FullscreenWrapper>
       </ViewerContainer>
     )

--- a/src/viewer/components/Slider.tsx
+++ b/src/viewer/components/Slider.tsx
@@ -1,4 +1,4 @@
-import MUISlider from "@material-ui/lab/Slider"
+import MUISlider, { SliderProps } from "@material-ui/lab/Slider"
 import debounce from "lodash.debounce"
 import React, { Component } from "react"
 
@@ -10,7 +10,7 @@ import {
 import DataManager from "../../managers/DataManager"
 import { GameManager } from "../../managers/GameManager"
 
-interface Props {}
+interface Props extends Partial<SliderProps> {}
 
 interface State {
   frame: number
@@ -72,6 +72,7 @@ class Slider extends Component<Props, State> {
           }}
         >
           <MUISlider
+            {...this.props}
             value={frame}
             aria-labelledby="label"
             onChange={this.handleChange}

--- a/src/viewer/components/icons/Camera.tsx
+++ b/src/viewer/components/icons/Camera.tsx
@@ -1,0 +1,23 @@
+/* tslint:disable */
+
+import React from "react"
+
+const Camera = () => {
+  return (
+    <div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4z"
+          fill="white"
+        />
+      </svg>
+    </div>
+  )
+}
+
+export default Camera

--- a/src/viewer/components/icons/PausedIcon.tsx
+++ b/src/viewer/components/icons/PausedIcon.tsx
@@ -1,0 +1,20 @@
+/* tslint:disable */
+
+import React from "react"
+
+const PausedIcon = () => {
+  return (
+    <div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+      >
+        <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" fill="white" />
+      </svg>
+    </div>
+  )
+}
+
+export default PausedIcon

--- a/src/viewer/components/icons/PlayIcon.tsx
+++ b/src/viewer/components/icons/PlayIcon.tsx
@@ -1,0 +1,20 @@
+/* tslint:disable */
+
+import React from "react"
+
+const PlayIcon = () => {
+  return (
+    <div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+      >
+        <path d="M8 5v14l11-7z" fill="white" />
+      </svg>
+    </div>
+  )
+}
+
+export default PlayIcon


### PR DESCRIPTION
Adds a few new features

- Adds compact controls that provide the same functionality as the standard set of controls provide.
- New compact view tab to testing page
- Optional `autoplay` prop added to replay viewer that will start or stop the clock on mount
- Caches requests for position data to prevent duplicate requests

Fixes a few bugs as well:

- Fixes a bug where the objects that spawn in the scene don't take their correct positions
- Fixes a bug where the "play" button doesn't match the initial state of the viewer
