### PR TITLE
update rl-loadout-lib to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4978,7 +4978,9 @@
       }
     },
     "rl-loadout-lib": {
-      "version": "0.3.0"
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/rl-loadout-lib/-/rl-loadout-lib-0.4.0.tgz",
+      "integrity": "sha512-MJXY73nVEPTcwUyZkzCDMwK9yKjy/LueeZCN+Z+V4Nfy2oIj6FLtWSPi1WGn5ENzCfF+VIZFBJe+h1ebb69vZg=="
     },
     "run-queue": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "moment": "^2.24.0",
     "pngjs": "^3.4.0",
     "react-full-screen": "^0.2.4",
-    "rl-loadout-lib": "^0.3.0",
+    "rl-loadout-lib": "^0.4.0",
     "styled-components": "^4.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This version now uses WebGL to generate textures vastly improving performance and load time. Idk why I haven't done this in the first place.