### PR TITLE
Add Github workflows for CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,17 @@
+name: "Build and Test"
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install packages
+      run: npm ci
+    - name: Build the project
+      run: npm run build
+    - name: Run linter
+      run: npm run lint

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths:
       - 'src/*'
-      - 'docs/*
+      - 'docs/*'
 
 jobs:
   build:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,10 @@
 name: "Build and Test"
 
-on: [push]
+on: 
+  push:
+    paths:
+      - 'src/*'
+      - 'docs/*
 
 jobs:
   build:
@@ -13,7 +17,7 @@ jobs:
       run: npm ci
     - name: Build the project
       run: npm run build
-    - name: Run linterLint
+    - name: Run linter
       uses: mooyoul/tslint-actions@v1.1.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,5 +13,8 @@ jobs:
       run: npm ci
     - name: Build the project
       run: npm run build
-    - name: Run linter
-      run: npm run lint
+    - name: Run linterLint
+      uses: mooyoul/tslint-actions@v1.1.1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        pattern: '*.ts'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Build the project
       run: npm run build
     - name: Publish to NPM
-    - uses: primer/publish@master
+      uses: primer/publish@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 name: Publish to NPM
 
 on:
-  release: published
+  release: 
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish to NPM
+
+on:
+  release: published
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install packages
+      run: npm ci
+    - name: Build the project
+      run: npm run build
+    - name: Publish to NPM
+    - uses: primer/publish@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        args: '--dir=lib'


### PR DESCRIPTION
Adds two Github workflows: one for building and linting and the other for publishing releases to NPM