### PR TITLE
update rl-loadout-lib to 0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4978,9 +4978,9 @@
       }
     },
     "rl-loadout-lib": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/rl-loadout-lib/-/rl-loadout-lib-0.4.0.tgz",
-      "integrity": "sha512-MJXY73nVEPTcwUyZkzCDMwK9yKjy/LueeZCN+Z+V4Nfy2oIj6FLtWSPi1WGn5ENzCfF+VIZFBJe+h1ebb69vZg=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/rl-loadout-lib/-/rl-loadout-lib-0.4.2.tgz",
+      "integrity": "sha512-/kSu7omFvukeuqa4Dih7KBHoQVGAE6YEOxfVnozWM+MknMigJ/sQaH9lkwQjc5zooi9Rc1ZHPTgIYnuNwtarDA=="
     },
     "run-queue": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "replay-viewer",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Rocket League replay viewer React component and tooling",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "moment": "^2.24.0",
     "pngjs": "^3.4.0",
     "react-full-screen": "^0.2.4",
-    "rl-loadout-lib": "^0.4.0",
+    "rl-loadout-lib": "^0.4.2",
     "styled-components": "^4.4.1"
   },
   "devDependencies": {

--- a/src/loaders/storage/loadRlLoadout.ts
+++ b/src/loaders/storage/loadRlLoadout.ts
@@ -39,7 +39,8 @@ export const loadRlLoadout = async (
     const bodyTask = manager.loadBody(
       player.loadout.car,
       paintConfig,
-      Body.DEFAULT
+      Body.DEFAULT,
+      player.loadout.skin
     )
 
     // TODO use the default wheel for now, there aren't a lot of wheels in rocket-loadout yet,


### PR DESCRIPTION
Falls back to HTMLCanvasElement if OffscreenCanvas is not present (not a polyfill!)
Applies decals to cars (only non animated)