### PR TITLE
Fix publisher settings to run manually

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,23 +1,22 @@
 name: Publish to NPM
 
 on:
-  release: 
+  release:
     types: [published]
 
 jobs:
-  build:
-
+  publish:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Install packages
-      run: npm ci
-    - name: Build the project
-      run: npm run build
-    - name: Publish to NPM
-      uses: primer/publish@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-        args: '--dir=lib'
+      - name: Checkout project
+        uses: actions/checkout@v1
+      - name: Install packages
+        run: npm ci
+      - name: Build the project
+        run: npm run build
+      - name: Publish to NPM
+        uses: npm run publish:lib
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "link": "npm link && cd docs && npm link replay-viewer",
     "submodule": "git submodule update --remote",
     "submodule:init": "git submodule update --init --remote",
+    "publish:lib": "cd lib && npm publish",
     "prepublishOnly": "echo 'Do not publish from root. Publish from lib'; exit 1"
   },
   "repository": {


### PR DESCRIPTION
The Github workflow use is dumpster so this just runs publish manually after a build