### PR TITLE
Fall back to basic Octane if rl-loadout fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "replay-viewer",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Rocket League replay viewer React component and tooling",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/builders/player/BasicPlayerBuilder.ts
+++ b/src/builders/player/BasicPlayerBuilder.ts
@@ -1,0 +1,57 @@
+import { Group, LoadingManager, Scene } from "three"
+
+import BasicCarAssets from "../../loaders/scenes/BasicCarAssets"
+import PlayerManager from "../../managers/models/PlayerManager"
+import { ExtendedPlayer } from "../../models/ReplayMetadata"
+import { getCarName, getGroupName } from "../utils/playerNameGetters"
+import { generateSprite } from "./generateSprite"
+import PlayerBuilder from "./PlayerBuilder"
+import { positionWheels } from "./positionWheels"
+
+export default class BasicPlayerBuilder implements PlayerBuilder {
+  private readonly basicCarAssets: BasicCarAssets
+
+  constructor(loadingManager?: LoadingManager) {
+    this.basicCarAssets = new BasicCarAssets(loadingManager)
+  }
+
+  async buildPlayers(
+    scene: Scene,
+    playerInfo: ExtendedPlayer[]
+  ): Promise<PlayerManager[]> {
+    await this.basicCarAssets.load()
+    return playerInfo.map((player) => this.buildCarGroup(scene, player))
+  }
+
+  private buildCarGroup(scene: Scene, player: ExtendedPlayer): PlayerManager {
+    const { orangeCar, blueCar, wheel } = this.basicCarAssets.getAssets()
+
+    orangeCar.children.forEach((child) => {
+      child.castShadow = true
+      child.receiveShadow = true
+    })
+    blueCar.children.forEach((child) => {
+      child.castShadow = true
+      child.receiveShadow = true
+    })
+    wheel.children.forEach((child) => {
+      child.castShadow = true
+      child.receiveShadow = true
+    })
+
+    // Build the car with its wheels (for rotation)
+    const car = player.isOrange ? orangeCar.clone(true) : blueCar.clone(true)
+    car.children.forEach((child) => (child.position.y += 31))
+    car.name = getCarName(player.name)
+    car.add(positionWheels(wheel))
+
+    // Build sprite and camera container (for position)
+    const group = new Group()
+    group.name = getGroupName(player.name)
+    group.add(car)
+    group.add(generateSprite(player.name, player.isOrange))
+
+    scene.add(group)
+    return new PlayerManager(player.name, player.isOrange, group)
+  }
+}

--- a/src/builders/player/PlayerBuilder.d.ts
+++ b/src/builders/player/PlayerBuilder.d.ts
@@ -1,0 +1,11 @@
+import { Scene } from "three"
+
+import PlayerManager from "../../managers/models/PlayerManager"
+import { ExtendedPlayer } from "../../models/ReplayMetadata"
+
+export default interface PlayerBuilder {
+  buildPlayers(
+    scene: Scene,
+    playerInfo: ExtendedPlayer[]
+  ): Promise<PlayerManager[]>
+}

--- a/src/builders/player/RLLoadoutPlayerBuilder.ts
+++ b/src/builders/player/RLLoadoutPlayerBuilder.ts
@@ -1,0 +1,65 @@
+import {
+  BodyModel,
+  RocketAssetManager,
+  RocketConfig,
+  TextureFormat,
+} from "rl-loadout-lib"
+import { Group, LoadingManager, Scene } from "three"
+import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader"
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader"
+
+import { loadRlLoadout } from "../../loaders/storage/loadRlLoadout"
+import PlayerManager from "../../managers/models/PlayerManager"
+import { ExtendedPlayer } from "../../models/ReplayMetadata"
+import { getCarName, getGroupName } from "../utils/playerNameGetters"
+import { generateSprite } from "./generateSprite"
+import PlayerBuilder from "./PlayerBuilder"
+
+export default class RLLoadoutPlayerBuilder implements PlayerBuilder {
+  private readonly manager: RocketAssetManager
+  private readonly defaultLoadouts: boolean
+
+  constructor(loadingManager?: LoadingManager, defaultLoadouts?: boolean) {
+    this.defaultLoadouts = defaultLoadouts || true
+    const gltfLoader = new GLTFLoader()
+    const dracoLoader = new DRACOLoader()
+    dracoLoader.setDecoderPath("/draco/")
+    gltfLoader.setDRACOLoader(dracoLoader)
+
+    const config = new RocketConfig({
+      gltfLoader,
+      loadingManager,
+      textureFormat: TextureFormat.PNG,
+      useCompressedModels: true,
+    })
+    this.manager = new RocketAssetManager(config)
+  }
+
+  async buildPlayers(
+    scene: Scene,
+    playerInfo: ExtendedPlayer[]
+  ): Promise<PlayerManager[]> {
+    const bodyPromises = playerInfo.map((player) =>
+      loadRlLoadout(this.manager, player, this.defaultLoadouts)
+    )
+    const bodies = await Promise.all(bodyPromises)
+
+    return bodies.map((value) => this.buildRocketLoadoutGroup(scene, value))
+  }
+
+  private buildRocketLoadoutGroup(
+    scene: Scene,
+    { body, player }: { body: BodyModel; player: ExtendedPlayer }
+  ) {
+    body.scene.name = getCarName(player.name)
+
+    // Build sprite and camera container (for position)
+    const group = new Group()
+    group.name = getGroupName(player.name)
+    group.add(body.scene)
+    group.add(generateSprite(player.name, player.isOrange))
+
+    scene.add(group)
+    return new PlayerManager(player.name, player.isOrange, group)
+  }
+}

--- a/src/loaders/scenes/BasicCarAssets.ts
+++ b/src/loaders/scenes/BasicCarAssets.ts
@@ -1,0 +1,40 @@
+import { Group, LoadingManager, Object3D } from "three"
+
+import { loadBlueCar, loadOrangeCar, loadWheel } from "../storage/loadCar"
+
+interface AvailableAssets {
+  orangeCar: Group
+  blueCar: Group
+  wheel: Object3D
+}
+
+export default class BasicCarAssets {
+  loadingManager: LoadingManager
+  assets?: AvailableAssets
+
+  constructor(loadingManager?: LoadingManager) {
+    this.loadingManager = loadingManager || new LoadingManager()
+  }
+
+  async load() {
+    const lm = this.loadingManager
+    return Promise.all([
+      loadOrangeCar(lm),
+      loadBlueCar(lm),
+      loadWheel(lm),
+    ]).then(([orangeCar, blueCar, wheel]) => {
+      this.assets = {
+        orangeCar,
+        blueCar,
+        wheel,
+      }
+    })
+  }
+
+  getAssets() {
+    if (!this.assets) {
+      throw new Error("Must call `load` before using assets for this scene")
+    }
+    return this.assets
+  }
+}

--- a/src/loaders/storage/loadCar.ts
+++ b/src/loaders/storage/loadCar.ts
@@ -1,0 +1,47 @@
+import { Group, LoadingManager } from "three"
+
+import { getChildByName } from "../operators/getChildByName"
+import { loadObject } from "../operators/loadObject"
+import { throwLoadingError } from "../operators/throwLoadingError"
+import { storageMemoize } from "./storageMemoize"
+
+export const loadWheel = (loadingManager?: LoadingManager) =>
+  storageMemoize(async () => {
+    const { default: glb } = await import(
+      // @ts-ignore
+      /* webpackChunkName: "Wheel" */ "../../assets/models/draco/Wheel.glb"
+    )
+    const wheelGLTF = await loadObject(glb, loadingManager)
+    const wheel = new Group()
+    wheel.name = "Wheel"
+    wheel.add(...wheelGLTF.scene.children)
+    return wheel
+  }, "WHEEL")
+
+export const loadOrangeCar = (loadingManager?: LoadingManager) =>
+  storageMemoize(async () => {
+    const { default: glb } = await import(
+      // @ts-ignore
+      /* webpackChunkName: "Octane_ZXR_Orange" */ "../../assets/models/draco/Octane_ZXR_Orange.glb"
+    )
+    const carGLTF = await loadObject(glb, loadingManager)
+    const car = getChildByName(carGLTF, "Octane")
+    if (!car) {
+      throwLoadingError("Octane")
+    }
+    return car as Group
+  }, "Octane_ZXR_Orange")
+
+export const loadBlueCar = (loadingManager?: LoadingManager) =>
+  storageMemoize(async () => {
+    const { default: glb } = await import(
+      // @ts-ignore
+      /* webpackChunkName: "Octane_ZXR_Blue" */ "../../assets/models/draco/Octane_ZXR_Blue.glb"
+    )
+    const carGLTF = await loadObject(glb, loadingManager)
+    const car = getChildByName(carGLTF, "Octane")
+    if (!car) {
+      throwLoadingError("Octane")
+    }
+    return car as Group
+  }, "Octane_ZXR_Blue")


### PR DESCRIPTION
~On Firefox, `OffscreenCanvas` fails and causes the page to crash. This edit will capture that exception and fallback to basic Octane car shapes~
Needless to say, the first example was fixed. However, any unhandled exception will cause the entire canvas to crash without recourse. I only expect this fallback to be utilized in cases where the user has shotty Internet connections and model loading is somehow interrupted. Something something solar flares too